### PR TITLE
Future friendly code style

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,3 +1,7 @@
 {
-    "esnext": true
+    "esnext": true,
+    "maximumLineLength": 120,
+    "disallowTrailingWhitespace": true,
+    "requireParenthesesAroundIIFE": true,
+    "requireCapitalizedConstructors": true
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -3,20 +3,16 @@
     "bitwise": true,
     "curly": true,
     "eqeqeq": false,
-    "immed": true,
     "latedef": true,
-    "maxlen": 120,
-    "newcap": true,
     "noarg": true,
     "nonbsp": true,
     "nonew": true,
-    "trailing": true,
     "undef": true,
     "unused": true,
 
     "globals": {
-        "console": true,
-        "setTimeout": true,
-        "process": true
+        "console": false,
+        "setTimeout": false,
+        "process": false
     }
 }


### PR DESCRIPTION
Some JSHint options used, are marked as deprecated in favor of JSCS.

| JSHint | JSCS |
| --- | --- |
| immed | requireParenthesesAroundIIFE |
| maxlen | maximumLineLength |
| newcap | requireCapitalizedConstructors |
| trailing | disallowTrailingWhitespace |

This updates for these new directions... =]

Additionally, sets properties in the `globals` options to `false`, to prevent unexpected attributions to these globals.

**Edit:** 
1. After submitting the pull request, I see which it's related with #10.
2. One CI build check has failed and I dont know why, and how make it pass... some tips?

Thanks!
